### PR TITLE
fix(release): trigger release on chore commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,18 @@
       "main"
     ],
     "plugins": [
-      "@semantic-release/commit-analyzer",
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "chore",
+          "releaseRules": [
+            {
+              "type": "chore",
+              "release": "patch"
+            }
+          ]
+        }
+      ],
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       "@semantic-release/npm",


### PR DESCRIPTION
Yea, we want to release more frequently. All current updates are just chores and they don't trigger release.