### PR TITLE
feat: add new rule react/jsx-key

### DIFF
--- a/react.js
+++ b/react.js
@@ -11,5 +11,6 @@ module.exports = {
       { extensions: ['.js', '.jsx', '.tsx'] },
     ],
     'react/jsx-props-no-spreading': 0,
+    'react/jsx-key': 'error',
   },
 }


### PR DESCRIPTION
Turn on rule to detect missing `key` prop in JSX. 

- main reason is ensure valid[ react syntax](https://reactjs.org/docs/lists-and-keys.html#keys).
- one downside can be a need to refactor old projects.

Examples of **incorrect** code for this rule:

```jsx
[<Hello />, <Hello />, <Hello />];
```

```jsx
data.map(x => <Hello>{x}</Hello>);
```

```jsx
<Hello {...{ key: id, id, caption }} />
```

In the last example the key is being spread, which is currently possible, but discouraged in favor of the statically provided key.

Examples of **correct** code for this rule:

```jsx
[<Hello key="first" />, <Hello key="second" />, <Hello key="third" />];
```

```jsx
data.map((x) => <Hello key={x.id}>{x}</Hello>);
```

```jsx
<Hello key={id} {...{ id, caption }} />
```


more info about [jsx/key-prop](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)


